### PR TITLE
feat: validate blocks with replay set, clear replay set

### DIFF
--- a/stacks-signer/src/client/mod.rs
+++ b/stacks-signer/src/client/mod.rs
@@ -419,6 +419,7 @@ pub(crate) mod tests {
             block_proposal_max_age_secs: config.block_proposal_max_age_secs,
             reorg_attempts_activity_timeout: config.reorg_attempts_activity_timeout,
             proposal_wait_for_parent_time: config.proposal_wait_for_parent_time,
+            validate_with_replay_tx: config.validate_with_replay_tx,
         }
     }
 

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -182,6 +182,8 @@ pub struct SignerConfig {
     /// Time to wait before submitting a block proposal to the stacks-node if we cannot
     ///  determine that the stacks-node has processed the parent
     pub proposal_wait_for_parent_time: Duration,
+    /// Whether or not to validate blocks with replay transactions
+    pub validate_with_replay_tx: bool,
 }
 
 /// The parsed configuration for the signer
@@ -233,6 +235,8 @@ pub struct GlobalConfig {
     pub proposal_wait_for_parent_time: Duration,
     /// Is this signer binary going to be running in dry-run mode?
     pub dry_run: bool,
+    /// Whether or not to validate blocks with replay transactions
+    pub validate_with_replay_tx: bool,
 }
 
 /// Internal struct for loading up the config file
@@ -282,6 +286,8 @@ struct RawConfigFile {
     pub proposal_wait_for_parent_time_secs: Option<u64>,
     /// Is this signer binary going to be running in dry-run mode?
     pub dry_run: Option<bool>,
+    /// Whether or not to validate blocks with replay transactions
+    pub validate_with_replay_tx: Option<bool>,
 }
 
 impl RawConfigFile {
@@ -403,6 +409,10 @@ impl TryFrom<RawConfigFile> for GlobalConfig {
                 .unwrap_or(DEFAULT_PROPOSAL_WAIT_TIME_FOR_PARENT_SECS),
         );
 
+        // TODO: remove this before going to mainnet
+        // https://github.com/stacks-network/stacks-core/issues/6087
+        let validate_with_replay_tx = raw_data.validate_with_replay_tx.unwrap_or(false);
+
         Ok(Self {
             node_host: raw_data.node_host,
             endpoint,
@@ -424,6 +434,7 @@ impl TryFrom<RawConfigFile> for GlobalConfig {
             dry_run,
             tenure_idle_timeout_buffer,
             proposal_wait_for_parent_time,
+            validate_with_replay_tx,
         })
     }
 }
@@ -465,6 +476,8 @@ Network: {network}
 Chain ID: 0x{chain_id}
 Database path: {db_path}
 Metrics endpoint: {metrics_endpoint}
+Dry run: {dry_run}
+Validate with replay tx: {validate_with_replay_tx}
 "#,
             node_host = self.node_host,
             endpoint = self.endpoint,
@@ -475,6 +488,8 @@ Metrics endpoint: {metrics_endpoint}
             network = self.network,
             db_path = self.db_path.to_str().unwrap_or_default(),
             metrics_endpoint = metrics_endpoint,
+            dry_run = self.dry_run,
+            validate_with_replay_tx = self.validate_with_replay_tx,
         )
     }
 
@@ -648,7 +663,7 @@ Metrics endpoint: 0.0.0.0:9090
 Chain ID: 2147483648
 "#;
 
-        let expected_str_v6 = r#"
+        let expected_str_v6: &'static str = r#"
 Stacks node host: 127.0.0.1:20443
 Signer endpoint: [::1]:30000
 Stacks address: ST3FPN8KBZ3YPBP0ZJGAAHTVFMQDTJCR5QPS7VTNJ
@@ -687,7 +702,7 @@ db_path = ":memory:"
         );
         let config = GlobalConfig::load_from_str(&config_toml).unwrap();
         assert_eq!(config.stacks_address.to_string(), expected_addr);
-
+        assert_eq!(config.validate_with_replay_tx, false);
         // 65 bytes (with compression flag)
         let sk_hex = "2de4e77aab89c0c2570bb8bb90824f5cf2a5204a975905fee450ff9dad0fcf2801";
 
@@ -699,11 +714,13 @@ endpoint = "localhost:30000"
 network = "mainnet"
 auth_password = "abcd"
 db_path = ":memory:"
+validate_with_replay_tx = true
             "#
         );
         let config = GlobalConfig::load_from_str(&config_toml).unwrap();
         assert_eq!(config.stacks_address.to_string(), expected_addr);
         assert_eq!(config.to_chain_id(), CHAIN_ID_MAINNET);
+        assert_eq!(config.validate_with_replay_tx, true);
     }
 
     #[test]

--- a/stacks-signer/src/runloop.rs
+++ b/stacks-signer/src/runloop.rs
@@ -323,6 +323,7 @@ impl<Signer: SignerTrait<T>, T: StacksMessageCodec + Clone + Send + Debug> RunLo
             block_proposal_max_age_secs: self.config.block_proposal_max_age_secs,
             reorg_attempts_activity_timeout: self.config.reorg_attempts_activity_timeout,
             proposal_wait_for_parent_time: self.config.proposal_wait_for_parent_time,
+            validate_with_replay_tx: self.config.validate_with_replay_tx,
         }))
     }
 

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -123,6 +123,8 @@ pub struct Signer {
     recently_processed: RecentlyProcessedBlocks<100>,
     /// The signer's global state evaluator
     pub global_state_evaluator: GlobalStateEvaluator,
+    /// Whether to validate blocks with replay transactions
+    pub validate_with_replay_tx: bool,
 }
 
 impl std::fmt::Display for SignerMode {
@@ -238,6 +240,7 @@ impl SignerTrait<SignerMessage> for Signer {
             local_state_machine: signer_state,
             recently_processed: RecentlyProcessedBlocks::new(),
             global_state_evaluator,
+            validate_with_replay_tx: signer_config.validate_with_replay_tx,
         }
     }
 
@@ -1608,7 +1611,7 @@ impl Signer {
         });
         match stacks_client.submit_block_for_validation(
             block.clone(),
-            if is_block_found {
+            if is_block_found || !self.validate_with_replay_tx {
                 None
             } else {
                 self.local_state_machine.get_tx_replay_set()

--- a/stackslib/src/net/api/tests/postblock_proposal.rs
+++ b/stackslib/src/net/api/tests/postblock_proposal.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::VecDeque;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Condvar, Mutex};
 
@@ -436,6 +437,7 @@ fn test_try_make_response() {
             cost,
             size,
             validation_time_ms,
+            replay_tx_hash,
         }) => {
             assert_eq!(
                 signer_signature_hash,
@@ -444,6 +446,7 @@ fn test_try_make_response() {
             assert_eq!(cost, ExecutionCost::ZERO);
             assert_eq!(size, 180);
             assert!(validation_time_ms > 0 && validation_time_ms < 60000);
+            assert!(replay_tx_hash.is_none());
         }
         _ => panic!("expected ok"),
     }
@@ -483,6 +486,7 @@ fn replay_validation_test(
     let mut rpc_test = TestRPC::setup_nakamoto(function_name!(), &test_observer);
 
     let (expected_replay_txs, block_txs) = setup_fn(&mut rpc_test);
+
     let mut requests = vec![];
 
     let (stacks_tip_ch, stacks_tip_bhh) = SortitionDB::get_canonical_stacks_chain_tip_hash(
@@ -567,7 +571,7 @@ fn replay_validation_test(
     let observer = ProposalTestObserver::new();
     let proposal_observer = Arc::clone(&observer.proposal_observer);
 
-    info!("Run request with observer for replay mismatch test");
+    info!("Run request with observer for validation with replay set test");
     let responses = rpc_test.run_with_observer(requests, Some(&observer));
 
     // Expect 202 Accepted initially
@@ -576,7 +580,7 @@ fn replay_validation_test(
     // Wait for the asynchronous validation result
     let start = std::time::Instant::now();
     loop {
-        info!("Wait for replay mismatch result to be non-empty");
+        info!("Wait for validation result to be non-empty");
         if proposal_observer
             .lock()
             .unwrap()
@@ -592,7 +596,7 @@ fn replay_validation_test(
         std::thread::sleep(std::time::Duration::from_secs(1));
         assert!(
             start.elapsed().as_secs() < 60,
-            "Timed out waiting for replay mismatch result"
+            "Timed out waiting for validation result"
         );
     }
 
@@ -690,6 +694,7 @@ fn replay_validation_test_transaction_unmineable_match() {
 /// Replay set has [mineable, unmineable, mineable]
 /// The block has [mineable, mineable]
 fn replay_validation_test_transaction_unmineable_match_2() {
+    let mut replay_set = vec![];
     let result = replay_validation_test(|rpc_test| {
         let miner_privk = &rpc_test.peer_1.miner.nakamoto_miner_key();
         // Unmineable tx
@@ -720,15 +725,18 @@ fn replay_validation_test_transaction_unmineable_match_2() {
             123,
         );
 
-        (
-            vec![unmineable_tx, mineable_tx.clone(), mineable_tx_2.clone()].into(),
-            vec![mineable_tx, mineable_tx_2],
-        )
+        replay_set = vec![unmineable_tx, mineable_tx.clone(), mineable_tx_2.clone()];
+
+        (replay_set.clone().into(), vec![mineable_tx, mineable_tx_2])
     });
 
     match result {
-        Ok(_) => {
-            // pass
+        Ok(block_validate_ok) => {
+            let mut hasher = DefaultHasher::new();
+            replay_set.hash(&mut hasher);
+            let replay_hash = hasher.finish();
+
+            assert_eq!(block_validate_ok.replay_tx_hash, Some(replay_hash));
         }
         Err(rejection) => {
             panic!("Expected validation to be OK, but got {:?}", rejection);
@@ -945,6 +953,83 @@ fn replay_validation_test_budget_exceeded() {
             assert_eq!(
                 rejection.reason_code,
                 ValidateRejectCode::InvalidTransactionReplay
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore]
+/// Replay set has [deploy, big_a, big_b]
+/// The block has [deploy, big_a]
+///
+/// The block is valid, but the replay set is _not_ exhausted.
+fn replay_validation_test_budget_exhausted() {
+    let mut replay_set = vec![];
+    let result = replay_validation_test(|rpc_test| {
+        let miner_privk = &rpc_test.peer_1.miner.nakamoto_miner_key();
+        let miner_addr = to_addr(miner_privk);
+
+        let contract_code = make_big_read_count_contract(BLOCK_LIMIT_MAINNET_21, 50);
+
+        let deploy_tx_bytes = make_contract_publish(
+            miner_privk,
+            36,
+            1000,
+            CHAIN_ID_TESTNET,
+            &"big-contract",
+            &contract_code,
+        );
+
+        let big_a_bytes = make_contract_call(
+            miner_privk,
+            37,
+            1000,
+            CHAIN_ID_TESTNET,
+            &miner_addr,
+            &"big-contract",
+            "big-tx",
+            &vec![],
+        );
+
+        let big_b_bytes = make_contract_call(
+            miner_privk,
+            38,
+            1000,
+            CHAIN_ID_TESTNET,
+            &miner_addr,
+            &"big-contract",
+            "big-tx",
+            &vec![],
+        );
+
+        let deploy_tx =
+            StacksTransaction::consensus_deserialize(&mut deploy_tx_bytes.as_slice()).unwrap();
+        let big_a = StacksTransaction::consensus_deserialize(&mut big_a_bytes.as_slice()).unwrap();
+        let big_b = StacksTransaction::consensus_deserialize(&mut big_b_bytes.as_slice()).unwrap();
+
+        let transfer_tx = make_stacks_transfer_tx(
+            miner_privk,
+            38,
+            1000,
+            CHAIN_ID_TESTNET,
+            &StandardPrincipalData::transient().into(),
+            100,
+        );
+
+        replay_set = vec![deploy_tx.clone(), big_a.clone(), big_b.clone()];
+
+        (replay_set.clone().into(), vec![deploy_tx, big_a])
+    });
+
+    match result {
+        Ok(block_validate_ok) => {
+            assert_eq!(block_validate_ok.replay_tx_hash, None);
+        }
+        Err(rejection) => {
+            panic!(
+                "Expected validation to be rejected, but got {:?}",
+                rejection
             );
         }
     }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3067,7 +3067,9 @@ fn tx_replay_forking_test() {
     let mut signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
         num_signers,
         vec![(sender_addr, (send_amt + send_fee) * 10)],
-        |_| {},
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
         |node_config| {
             node_config.miner.block_commit_delay = Duration::from_secs(1);
             node_config.miner.replay_transactions = true;
@@ -3423,7 +3425,9 @@ fn tx_replay_e2e_test() {
             (sender_addr, send_amt + send_fee),
             (sender_addr2, send_amt + send_fee),
         ],
-        |_| {},
+        |c| {
+            c.validate_with_replay_tx = true;
+        },
         |node_config| {
             node_config.miner.block_commit_delay = Duration::from_secs(1);
             node_config.miner.replay_transactions = true;


### PR DESCRIPTION
Opening this PR to get eyes on this implementation. This PR builds on top of both https://github.com/stacks-network/stacks-core/pull/6020 and https://github.com/stacks-network/stacks-core/pull/6077. To keep this PR "clean", the base branch for is a combination of those two PRs.

This PR implements two main things:

- Validating that a proposed block contains the replay set (if we're in replay mode)
- Clearing the replay set if we're "done" with transaction replay

Knowing if we should be "done" with replay is tricky. What this implementation does is add a field to `BlockValidateOk` with a hash of the replay set. This field is only present if the block was validated against a replay set _and_ it exhausted the replay set. Basically, it's saying "after this block, we can move out of replay". The signer stores this (block_hash, replay_set_exhausted) tuple. Then, in `stacks_block_arrival`, the signer state machine checks if we should move out of replay based on this lookup.

I've added a test (`tx_replay_e2e_test`) which is mainly @jferrant's code from https://github.com/stacks-network/stacks-core/pull/6031/files#diff-9fbead3ef50a4b19fa3c1ce9c11952010f8506706db040df2d85459fe8d518b7 demonstrating:

- bitcoin forks, we go into replay mode
- miner tries to make a non-replay block, gets rejected
- miner makes a replay block, gets approved
- replay set is cleared after
- regular mining resumes

This PR is definitely missing some edge cases, and likely will break other tests, but I wanted to get some eyes on it first.