### PR TITLE
feat: TenureExtend during tx replay

### DIFF
--- a/libsigner/src/libsigner.rs
+++ b/libsigner/src/libsigner.rs
@@ -58,7 +58,7 @@ use stacks_common::versions::STACKS_SIGNER_VERSION;
 pub use crate::error::{EventError, RPCError};
 pub use crate::events::{
     BlockProposal, BlockProposalData, BurnBlockEvent, EventReceiver, EventStopSignaler,
-    SignerEvent, SignerEventReceiver, SignerEventTrait, SignerStopSignaler,
+    SignerEvent, SignerEventReceiver, SignerEventTrait, SignerStopSignaler, StacksBlockEvent,
 };
 pub use crate::runloop::{RunningSigner, Signer, SignerRunLoop};
 pub use crate::session::{SignerSession, StackerDBSession};

--- a/libsigner/src/tests/signer_state.rs
+++ b/libsigner/src/tests/signer_state.rs
@@ -29,7 +29,9 @@ use crate::v0::messages::{
     StateMachineUpdate as StateMachineUpdateMessage, StateMachineUpdateContent,
     StateMachineUpdateMinerState,
 };
-use crate::v0::signer_state::{GlobalStateEvaluator, ReplayTransactionSet, SignerStateMachine};
+use crate::v0::signer_state::{
+    CreationTime, GlobalStateEvaluator, ReplayTransactionSet, SignerStateMachine,
+};
 
 fn generate_global_state_evaluator(num_addresses: u32) -> GlobalStateEvaluator {
     let address_weights = generate_random_address_with_equal_weights(num_addresses);
@@ -243,7 +245,7 @@ fn determine_global_states() {
         current_miner: (&current_miner).into(),
         active_signer_protocol_version: local_supported_signer_protocol_version, // a majority of signers are saying they support version the same local_supported_signer_protocol_version, so update it here...
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     global_eval.insert_update(local_address, local_update);
@@ -283,7 +285,7 @@ fn determine_global_states() {
         current_miner: (&new_miner).into(),
         active_signer_protocol_version: local_supported_signer_protocol_version, // a majority of signers are saying they support version the same local_supported_signer_protocol_version, so update it here...
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     global_eval.insert_update(local_address, new_update);
@@ -324,7 +326,7 @@ fn determine_global_states_with_tx_replay_set() {
         current_miner: (&current_miner).into(),
         active_signer_protocol_version, // a majority of signers are saying they support version the same local_supported_signer_protocol_version, so update it here...
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     let burn_block = ConsensusHash([20u8; 20]);
@@ -362,7 +364,7 @@ fn determine_global_states_with_tx_replay_set() {
         current_miner: (&current_miner).into(),
         active_signer_protocol_version: local_supported_signer_protocol_version, // a majority of signers are saying they support version the same local_supported_signer_protocol_version, so update it here...
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     // Let's tip the scales over to the correct burn view
@@ -419,7 +421,7 @@ fn determine_global_states_with_tx_replay_set() {
         current_miner: (&current_miner).into(),
         active_signer_protocol_version,
         tx_replay_set: ReplayTransactionSet::new(vec![tx]),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     assert_eq!(

--- a/stacks-signer/src/chainstate.rs
+++ b/stacks-signer/src/chainstate.rs
@@ -404,6 +404,7 @@ impl SortitionsView {
             // in tenure extends, we need to check:
             // (1) if this is the most recent sortition, an extend is allowed if it changes the burnchain view
             // (2) if this is the most recent sortition, an extend is allowed if enough time has passed to refresh the block limit
+            // (3) if we are in replay, an extend is allowed
             let changed_burn_view = tenure_extend.burn_view_consensus_hash != tenure_id;
             let extend_timestamp = signer_db.calculate_tenure_extend_timestamp(
                 self.config.tenure_idle_timeout,
@@ -412,7 +413,8 @@ impl SortitionsView {
             );
             let epoch_time = get_epoch_time_secs();
             let enough_time_passed = epoch_time >= extend_timestamp;
-            if !changed_burn_view && !enough_time_passed {
+            let is_in_replay = self.signer_state.tx_replay_set.is_some();
+            if !is_in_replay && !changed_burn_view && !enough_time_passed {
                 warn!(
                     "Miner block proposal contains a tenure extend, but the burnchain view has not changed and enough time has not passed to refresh the block limit. Considering proposal invalid.";
                     "proposed_block_consensus_hash" => %block.header.consensus_hash,

--- a/stacks-signer/src/tests/chainstate.rs
+++ b/stacks-signer/src/tests/chainstate.rs
@@ -30,7 +30,7 @@ use clarity::types::chainstate::{BurnchainHeaderHash, SortitionId, StacksAddress
 use clarity::types::PrivateKey;
 use libsigner::v0::messages::RejectReason;
 use libsigner::v0::signer_state::{
-    GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
+    CreationTime, GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
 };
 use libsigner::{BlockProposal, BlockProposalData};
 use stacks_common::bitvec::BitVec;
@@ -140,7 +140,7 @@ fn setup_test_environment(
         },
         active_signer_protocol_version: 0,
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     let sortitions_view = SortitionsView {

--- a/stacks-signer/src/tests/signer_state.rs
+++ b/stacks-signer/src/tests/signer_state.rs
@@ -32,7 +32,7 @@ use libsigner::v0::messages::{
     StateMachineUpdateMinerState,
 };
 use libsigner::v0::signer_state::{
-    GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
+    CreationTime, GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
 };
 
 use crate::chainstate::{ProposalEvalConfig, SortitionState};
@@ -172,7 +172,7 @@ fn check_capitulate_miner_view() {
         current_miner: (&new_miner).into(),
         tx_replay_set: ReplayTransactionSet::none(),
         active_signer_protocol_version,
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
 
     let mut local_state_machine = LocalStateMachine::Initialized(signer_state_machine.clone());
@@ -344,7 +344,7 @@ fn check_miner_inactivity_timeout() {
         current_miner: inactive_miner,
         active_signer_protocol_version: 0,
         tx_replay_set: ReplayTransactionSet::none(),
-        creation_time: SystemTime::now(),
+        creation_time: CreationTime::now(),
     };
     local_state_machine = LocalStateMachine::Initialized(signer_state.clone());
     local_state_machine

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -276,7 +276,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 .unwrap_or_else(|e| error!("{self}: failed to update local state machine for pending update"; "err" => ?e));
         }
 
-        if prior_state.should_broadcast_update(&self.local_state_machine) {
+        if prior_state != self.local_state_machine {
             let version = self.get_signer_protocol_version();
             self.local_state_machine
                 .send_signer_update_message(&mut self.stackerdb, version);
@@ -323,7 +323,7 @@ impl SignerTrait<SignerMessage> for Signer {
         self.check_submitted_block_proposal();
         self.check_pending_block_validations(stacks_client);
 
-        if prior_state.should_broadcast_update(&self.local_state_machine) {
+        if prior_state != self.local_state_machine {
             let version = self.get_signer_protocol_version();
             self.local_state_machine
                 .send_signer_update_message(&mut self.stackerdb, version);

--- a/stacks-signer/src/v0/signer.rs
+++ b/stacks-signer/src/v0/signer.rs
@@ -276,7 +276,7 @@ impl SignerTrait<SignerMessage> for Signer {
                 .unwrap_or_else(|e| error!("{self}: failed to update local state machine for pending update"; "err" => ?e));
         }
 
-        if prior_state != self.local_state_machine {
+        if prior_state.should_broadcast_update(&self.local_state_machine) {
             let version = self.get_signer_protocol_version();
             self.local_state_machine
                 .send_signer_update_message(&mut self.stackerdb, version);
@@ -323,7 +323,7 @@ impl SignerTrait<SignerMessage> for Signer {
         self.check_submitted_block_proposal();
         self.check_pending_block_validations(stacks_client);
 
-        if prior_state != self.local_state_machine {
+        if prior_state.should_broadcast_update(&self.local_state_machine) {
             let version = self.get_signer_protocol_version();
             self.local_state_machine
                 .send_signer_update_message(&mut self.stackerdb, version);

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -30,7 +30,7 @@ use libsigner::v0::messages::{
     StateMachineUpdateContent, StateMachineUpdateMinerState,
 };
 use libsigner::v0::signer_state::{
-    GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
+    CreationTime, GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
 };
 use serde::{Deserialize, Serialize};
 use stacks_common::codec::Error as CodecError;
@@ -104,7 +104,7 @@ impl LocalStateMachine {
     pub fn get_creation_time(&self) -> Option<SystemTime> {
         match self {
             LocalStateMachine::Initialized(update)
-            | LocalStateMachine::Pending { prior: update, .. } => Some(update.creation_time),
+            | LocalStateMachine::Pending { prior: update, .. } => Some(update.creation_time.0),
             LocalStateMachine::Uninitialized => None,
         }
     }
@@ -169,7 +169,7 @@ impl LocalStateMachine {
             current_miner: MinerState::NoValidMiner,
             active_signer_protocol_version: SUPPORTED_SIGNER_PROTOCOL_VERSION,
             tx_replay_set: ReplayTransactionSet::none(),
-            creation_time: SystemTime::now(),
+            creation_time: CreationTime::now(),
         }
     }
 
@@ -560,7 +560,7 @@ impl LocalStateMachine {
             current_miner: miner_state,
             active_signer_protocol_version: prior_state_machine.active_signer_protocol_version,
             tx_replay_set,
-            creation_time: SystemTime::now(),
+            creation_time: CreationTime::now(),
         });
 
         if prior_state != *self {
@@ -633,7 +633,7 @@ impl LocalStateMachine {
                 current_miner: current_miner.into(),
                 active_signer_protocol_version,
                 tx_replay_set,
-                creation_time: SystemTime::now(),
+                creation_time: CreationTime::now(),
             });
             // Because we updated our active signer protocol version, update local_update so its included in the subsequent evaluations
             let Ok(update) =
@@ -703,7 +703,7 @@ impl LocalStateMachine {
                 current_miner: (&new_miner).into(),
                 active_signer_protocol_version,
                 tx_replay_set,
-                creation_time: SystemTime::now(),
+                creation_time: CreationTime::now(),
             });
         }
     }

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -941,4 +941,19 @@ impl LocalStateMachine {
             .collect::<Vec<_>>();
         Ok(Some(forked_txs))
     }
+
+    /// Determines if the local state machine should broadcast an update by comparing
+    /// to a prior state.
+    ///
+    /// This is needed because `PartialEq` on [`SignerStateMachine`] excludes
+    /// the `tx_replay_set` field.
+    pub fn should_broadcast_update(&self, prior_state: &LocalStateMachine) -> bool {
+        // Base `PartialEq` check
+        if self != prior_state {
+            return true;
+        }
+
+        // Check if the tx replay set is different
+        self.get_tx_replay_set() != prior_state.get_tx_replay_set()
+    }
 }

--- a/stacks-signer/src/v0/signer_state.rs
+++ b/stacks-signer/src/v0/signer_state.rs
@@ -941,19 +941,4 @@ impl LocalStateMachine {
             .collect::<Vec<_>>();
         Ok(Some(forked_txs))
     }
-
-    /// Determines if the local state machine should broadcast an update by comparing
-    /// to a prior state.
-    ///
-    /// This is needed because `PartialEq` on [`SignerStateMachine`] excludes
-    /// the `tx_replay_set` field.
-    pub fn should_broadcast_update(&self, prior_state: &LocalStateMachine) -> bool {
-        // Base `PartialEq` check
-        if self != prior_state {
-            return true;
-        }
-
-        // Check if the tx replay set is different
-        self.get_tx_replay_set() != prior_state.get_tx_replay_set()
-    }
 }

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -1601,7 +1601,6 @@ impl BlockMinerThread {
             }
         };
         // Check if we can and should include a time-based tenure extend.
-        info!("Tenure extend: Checking if we can and should include a time-based tenure extend");
         if self.last_block_mined.is_some() {
             if self.config.miner.replay_transactions
                 && coordinator
@@ -1619,7 +1618,6 @@ impl BlockMinerThread {
                     .tenure_budget
                     .proportion_largest_dimension(&self.tenure_cost);
                 if usage < self.config.miner.tenure_extend_cost_threshold {
-                    info!("Tenure extend: Not extending tenure because we have spent less than 50% of the budget");
                     return Ok(NakamotoTenureInfo {
                         coinbase_tx: None,
                         tenure_change_tx: None,
@@ -1627,19 +1625,9 @@ impl BlockMinerThread {
                 }
 
                 let tenure_extend_timestamp = coordinator.get_tenure_extend_timestamp();
-                info!(
-                    "Tenure extend: Tenure extend timestamp: {}",
-                    tenure_extend_timestamp
-                );
                 if get_epoch_time_secs() <= tenure_extend_timestamp
                     && self.tenure_change_time.elapsed() <= self.config.miner.tenure_timeout
                 {
-                    info!("Tenure extend: Not extending tenure because the timestamp is in the future";
-                        "current_timestamp" => get_epoch_time_secs(),
-                        "tenure_extend_timestamp" => tenure_extend_timestamp,
-                        "tenure_change_time_elapsed" => self.tenure_change_time.elapsed().as_secs(),
-                        "tenure_timeout_secs" => self.config.miner.tenure_timeout.as_secs(),
-                    );
                     return Ok(NakamotoTenureInfo {
                         coinbase_tx: None,
                         tenure_change_tx: None,

--- a/testnet/stacks-node/src/nakamoto_node/miner.rs
+++ b/testnet/stacks-node/src/nakamoto_node/miner.rs
@@ -1601,36 +1601,59 @@ impl BlockMinerThread {
             }
         };
         // Check if we can and should include a time-based tenure extend.
+        info!("Tenure extend: Checking if we can and should include a time-based tenure extend");
         if self.last_block_mined.is_some() {
-            // Do not extend if we have spent < 50% of the budget, since it is
-            // not necessary.
-            let usage = self
-                .tenure_budget
-                .proportion_largest_dimension(&self.tenure_cost);
-            if usage < self.config.miner.tenure_extend_cost_threshold {
-                return Ok(NakamotoTenureInfo {
-                    coinbase_tx: None,
-                    tenure_change_tx: None,
-                });
-            }
-
-            let tenure_extend_timestamp = coordinator.get_tenure_extend_timestamp();
-            if get_epoch_time_secs() <= tenure_extend_timestamp
-                && self.tenure_change_time.elapsed() <= self.config.miner.tenure_timeout
+            if self.config.miner.replay_transactions
+                && coordinator
+                    .get_signer_global_state()
+                    .map(|state| state.tx_replay_set.is_some())
+                    .unwrap_or(false)
             {
-                return Ok(NakamotoTenureInfo {
-                    coinbase_tx: None,
-                    tenure_change_tx: None,
-                });
-            }
+                // we're in replay, we should always TenureExtend
+                info!("Tenure extend: In replay, always extending tenure");
+                self.tenure_extend_reset();
+            } else {
+                // Do not extend if we have spent < 50% of the budget, since it is
+                // not necessary.
+                let usage = self
+                    .tenure_budget
+                    .proportion_largest_dimension(&self.tenure_cost);
+                if usage < self.config.miner.tenure_extend_cost_threshold {
+                    info!("Tenure extend: Not extending tenure because we have spent less than 50% of the budget");
+                    return Ok(NakamotoTenureInfo {
+                        coinbase_tx: None,
+                        tenure_change_tx: None,
+                    });
+                }
 
-            info!("Miner: Time-based tenure extend";
-                "current_timestamp" => get_epoch_time_secs(),
-                "tenure_extend_timestamp" => tenure_extend_timestamp,
-                "tenure_change_time_elapsed" => self.tenure_change_time.elapsed().as_secs(),
-                "tenure_timeout_secs" => self.config.miner.tenure_timeout.as_secs(),
-            );
-            self.tenure_extend_reset();
+                let tenure_extend_timestamp = coordinator.get_tenure_extend_timestamp();
+                info!(
+                    "Tenure extend: Tenure extend timestamp: {}",
+                    tenure_extend_timestamp
+                );
+                if get_epoch_time_secs() <= tenure_extend_timestamp
+                    && self.tenure_change_time.elapsed() <= self.config.miner.tenure_timeout
+                {
+                    info!("Tenure extend: Not extending tenure because the timestamp is in the future";
+                        "current_timestamp" => get_epoch_time_secs(),
+                        "tenure_extend_timestamp" => tenure_extend_timestamp,
+                        "tenure_change_time_elapsed" => self.tenure_change_time.elapsed().as_secs(),
+                        "tenure_timeout_secs" => self.config.miner.tenure_timeout.as_secs(),
+                    );
+                    return Ok(NakamotoTenureInfo {
+                        coinbase_tx: None,
+                        tenure_change_tx: None,
+                    });
+                }
+
+                info!("Miner: Time-based tenure extend";
+                    "current_timestamp" => get_epoch_time_secs(),
+                    "tenure_extend_timestamp" => tenure_extend_timestamp,
+                    "tenure_change_time_elapsed" => self.tenure_change_time.elapsed().as_secs(),
+                    "tenure_timeout_secs" => self.config.miner.tenure_timeout.as_secs(),
+                );
+                self.tenure_extend_reset();
+            }
         }
 
         let parent_block_id = parent_block_info.stacks_parent_header.index_block_hash();

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 use std::{env, thread};
 
 use clarity::vm::ast::ASTRules;
@@ -34,7 +34,7 @@ use libsigner::v0::messages::{
     StateMachineUpdateContent, StateMachineUpdateMinerState,
 };
 use libsigner::v0::signer_state::{
-    GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
+    CreationTime, GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
 };
 use libsigner::{SignerSession, StackerDBSession};
 use rand::{thread_rng, Rng};
@@ -6645,7 +6645,7 @@ fn signer_chainstate() {
                 current_miner: miner_state,
                 active_signer_protocol_version: SUPPORTED_SIGNER_PROTOCOL_VERSION,
                 tx_replay_set: ReplayTransactionSet::none(),
-                creation_time: SystemTime::now(),
+                creation_time: CreationTime::now(),
             };
 
             SortitionsView {

--- a/testnet/stacks-node/src/tests/nakamoto_integrations.rs
+++ b/testnet/stacks-node/src/tests/nakamoto_integrations.rs
@@ -36,7 +36,7 @@ use libsigner::v0::messages::{
 use libsigner::v0::signer_state::{
     GlobalStateEvaluator, MinerState, ReplayTransactionSet, SignerStateMachine,
 };
-use libsigner::{SignerSession, StackerDBSession};
+use libsigner::{SignerSession, StackerDBSession, StacksBlockEvent};
 use rand::{thread_rng, Rng};
 use rusqlite::{Connection, OptionalExtension};
 use stacks::burnchains::{MagicBytes, Txid};
@@ -12695,34 +12695,45 @@ fn miner_constructs_replay_block() {
     assert_eq!(tenure_change.cause, TenureChangeCause::BlockFound);
 
     info!("Verifying next block contains the expected replay txs...");
+    let block: StacksBlockEvent =
+        serde_json::from_value(blocks[blocks_before + 1].clone()).expect("Failed to parse block");
+    let tx = block.transactions.get(0).unwrap();
+    assert!(matches!(
+        tx.payload,
+        TransactionPayload::TenureChange(TenureChangePayload {
+            cause: TenureChangeCause::Extended,
+            ..
+        })
+    ));
+
     let block = &observed_blocks[observed_before + 1];
-    assert_eq!(block.tx_events.len(), 6);
-    if let TransactionEvent::Success(tx) = &block.tx_events[0] {
+    assert_eq!(block.tx_events.len(), 7);
+    if let TransactionEvent::Success(tx) = &block.tx_events[1] {
         assert_eq!(tx.txid, succeed_tx_1.txid());
     } else {
         panic!("Failed to mine the first tx");
     };
-    if let TransactionEvent::Success(tx) = &block.tx_events[1] {
+    if let TransactionEvent::Success(tx) = &block.tx_events[2] {
         assert_eq!(tx.txid, succeed_tx_2.txid());
     } else {
         panic!("Failed to mine the second tx");
     };
-    if let TransactionEvent::ProcessingError(tx) = &block.tx_events[2] {
+    if let TransactionEvent::ProcessingError(tx) = &block.tx_events[3] {
         assert_eq!(tx.txid, fail_tx_3.txid());
     } else {
         panic!("Failed to error on the third tx");
     };
-    if let TransactionEvent::ProcessingError(tx) = &block.tx_events[3] {
+    if let TransactionEvent::ProcessingError(tx) = &block.tx_events[4] {
         assert_eq!(tx.txid, fail_tx_4.txid());
     } else {
         panic!("Failed to error on the fourth tx");
     };
-    if let TransactionEvent::Success(tx) = &block.tx_events[4] {
+    if let TransactionEvent::Success(tx) = &block.tx_events[5] {
         assert_eq!(tx.txid, succeed_tx_5.txid());
     } else {
         panic!("Failed to mine the fifth tx");
     };
-    if let TransactionEvent::Success(tx) = &block.tx_events[5] {
+    if let TransactionEvent::Success(tx) = &block.tx_events[6] {
         assert_eq!(tx.txid, succeed_tx_6.txid());
     } else {
         panic!("Failed to mine the sixth tx");

--- a/testnet/stacks-node/src/tests/signer/mod.rs
+++ b/testnet/stacks-node/src/tests/signer/mod.rs
@@ -646,6 +646,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     pub fn submit_contract_deploy(
         &self,
         sender_sk: &StacksPrivateKey,
+        tx_fee: u64,
         contract_code: &str,
         contract_name: &str,
     ) -> Result<(String, u64), String> {
@@ -656,7 +657,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
         let contract_tx = make_contract_publish(
             &sender_sk,
             sender_nonce,
-            1000,
+            tx_fee,
             self.running_nodes.conf.burnchain.chain_id,
             contract_name,
             contract_code,
@@ -716,8 +717,12 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
          (define-public (run-update)
            (ok (var-set local-burn-block-ht burn-block-height)))
         ";
-        let (txid, sender_nonce) =
-            self.submit_contract_deploy(sender_sk, burn_height_contract, "burn-height-local")?;
+        let (txid, sender_nonce) = self.submit_contract_deploy(
+            sender_sk,
+            1000,
+            burn_height_contract,
+            "burn-height-local",
+        )?;
 
         self.wait_for_nonce_increase(&to_addr(&sender_sk), sender_nonce)?;
         Ok(txid)
@@ -1005,7 +1010,7 @@ impl<S: Signer<T> + Send + 'static, T: SignerEventTrait + 'static> SignerTest<Sp
     pub fn wait_for_signer_state_check(
         &self,
         timeout: u64,
-        f: impl Fn(&LocalStateMachine) -> Result<bool, String>,
+        mut f: impl FnMut(&LocalStateMachine) -> Result<bool, String>,
     ) -> Result<(), String> {
         wait_for(timeout, || {
             let (signer_states, _) = self.get_burn_updated_states();

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -806,9 +806,11 @@ impl MultipleMinerTest {
                 && self.get_peer_info().burn_block_height >= burn_block_before + nmb_blocks)
         })?;
         let peer_after = self.get_peer_info();
-        wait_for_state_machine_update_by_miner_tenure_id(
-            30,
+        wait_for_state_machine_update(
+            timeout_secs,
             &peer_after.pox_consensus,
+            peer_after.burn_block_height,
+            None,
             &self.signer_test.signer_test_pks(),
             SUPPORTED_SIGNER_PROTOCOL_VERSION,
         )

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -27,7 +27,8 @@ use libsigner::v0::messages::{
     RejectReason, SignerMessage, StateMachineUpdateContent, StateMachineUpdateMinerState,
 };
 use libsigner::{
-    BlockProposal, BlockProposalData, SignerSession, StackerDBSession, VERSION_STRING,
+    BlockProposal, BlockProposalData, SignerSession, StackerDBSession, StacksBlockEvent,
+    VERSION_STRING,
 };
 use madhouse::{execute_commands, prop_allof, scenario, Command};
 use pinny::tag;
@@ -4949,6 +4950,16 @@ fn snapshot_test() {
 #[ignore]
 /// Trigger a Bitcoin fork that creates a replay set that
 /// contains more transactions than can fit into a tenure's budget.
+///
+/// The test scenario:
+///
+/// - Deploy a contract (`big-contract`) that, when called, has >= 50% of a tenure's budget
+/// - Mine a few BTC blocks
+/// - Mine two blocks that contain `big-contract` calls
+/// - Trigger a fork that includes the two big transactions
+/// - Ensure that the miner produces TenureExtend transactions
+///   that allow the replay set to be cleared more quickly than
+///   via time-based tenure extends.
 fn tx_replay_budget_exceeded_tenure_extend() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
@@ -5079,31 +5090,19 @@ fn tx_replay_budget_exceeded_tenure_extend() {
         .unwrap();
     }
 
-    let mut last_log = Instant::now();
-    last_log -= Duration::from_secs(5);
     signer_test
         .wait_for_signer_state_check(30, |state| {
             let Some(tx_replay_set) = state.get_tx_replay_set() else {
-                if last_log.elapsed() > Duration::from_secs(5) {
-                    info!("---- tx_replay_set: none -----");
-                    last_log = Instant::now();
-                }
                 return Ok(false);
             };
             let len_ok = tx_replay_set.len() == 2;
             let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
             let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
-            if last_log.elapsed() > Duration::from_secs(5) {
-                info!("---- tx_replay_set: -----";
-                    "len" => tx_replay_set.len(),
-                    "txid1" => tx_replay_set[0].txid().to_hex(),
-                    "txid2" => tx_replay_set[1].txid().to_hex(),
-                );
-                last_log = Instant::now();
-            }
             Ok(len_ok && txid1_ok && txid2_ok)
         })
         .expect("Timed out waiting for tx replay set");
+
+    let blocks_before = test_observer::get_blocks().len();
 
     TEST_MINE_STALL.set(false);
 
@@ -5116,6 +5115,60 @@ fn tx_replay_budget_exceeded_tenure_extend() {
             Ok(tx_replay_set.is_none())
         })
         .expect("Timed out waiting for tx replay set to be cleared");
+
+    // Validate that the blocks produced are correct
+
+    let blocks = test_observer::get_blocks()
+        .clone()
+        .into_iter()
+        .skip(blocks_before)
+        .map(|b| serde_json::from_value::<StacksBlockEvent>(b).unwrap())
+        .collect::<Vec<_>>();
+
+    // first is just a tenureChange + coinbase
+    let block = &blocks[0];
+    info!("---- block ----";
+        "transactions" => ?block.transactions,
+    );
+    assert!(matches!(
+        block.transactions[0].payload,
+        TransactionPayload::TenureChange(TenureChangePayload {
+            cause: TenureChangeCause::BlockFound,
+            ..
+        })
+    ));
+    assert!(matches!(
+        block.transactions[1].payload,
+        TransactionPayload::Coinbase(..)
+    ));
+
+    // second should be extend + tx1
+    let block = &blocks[1];
+    info!("---- block ----";
+        "transactions" => ?block.transactions,
+    );
+    assert!(matches!(
+        block.transactions[0].payload,
+        TransactionPayload::TenureChange(TenureChangePayload {
+            cause: TenureChangeCause::Extended,
+            ..
+        })
+    ));
+    assert_eq!(block.transactions[1].txid().to_hex(), txid1);
+
+    // third should be extend + tx2
+    let block = &blocks[2];
+    info!("---- block ----";
+        "transactions" => ?block.transactions,
+    );
+    assert!(matches!(
+        block.transactions[0].payload,
+        TransactionPayload::TenureChange(TenureChangePayload {
+            cause: TenureChangeCause::Extended,
+            ..
+        })
+    ));
+    assert_eq!(block.transactions[1].txid().to_hex(), txid2);
 
     signer_test.shutdown();
 }

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -3506,35 +3506,42 @@ fn tx_replay_reject_invalid_proposals_during_replay() {
     }
 
     let num_signers = 5;
-    let sender_sk = Secp256k1PrivateKey::random();
+    let sender_sk = Secp256k1PrivateKey::from_seed("sender_1".as_bytes());
     let sender_addr = tests::to_addr(&sender_sk);
-    let sender_sk2 = Secp256k1PrivateKey::random();
+    let sender_sk2 = Secp256k1PrivateKey::from_seed("sender_2".as_bytes());
     let sender_addr2 = tests::to_addr(&sender_sk2);
     let send_amt = 100;
     let send_fee = 180;
-    let signer_test: SignerTest<SpawnedSigner> = SignerTest::new_with_config_modifications(
-        num_signers,
-        vec![
-            (sender_addr, send_amt + send_fee),
-            (sender_addr2, send_amt + send_fee),
-        ],
-        |c| {
-            c.validate_with_replay_tx = true;
-        },
-        |node_config| {
-            node_config.miner.block_commit_delay = Duration::from_secs(1);
-            node_config.miner.replay_transactions = true;
-        },
-        None,
-        None,
-    );
+    let signer_test: SignerTest<SpawnedSigner> =
+        SignerTest::new_with_config_modifications_and_snapshot(
+            num_signers,
+            vec![
+                (sender_addr, send_amt + send_fee),
+                (sender_addr2, send_amt + send_fee),
+            ],
+            |c| {
+                c.validate_with_replay_tx = true;
+            },
+            |node_config| {
+                node_config.miner.block_commit_delay = Duration::from_secs(1);
+                node_config.miner.replay_transactions = true;
+                node_config.miner.activated_vrf_key_path =
+                    Some(format!("{}/vrf_key", node_config.node.working_dir));
+            },
+            None,
+            None,
+            Some(function_name!()),
+        );
     let conf = &signer_test.running_nodes.conf;
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
     let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
 
     let stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
 
-    signer_test.boot_to_epoch_3();
+    if signer_test.bootstrap_snapshot() {
+        signer_test.shutdown_and_snapshot();
+        return;
+    }
     info!("------------------------- Reached Epoch 3.0 -------------------------");
     let pre_fork_tenures = 10;
 

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -4959,7 +4959,7 @@ fn tx_replay_budget_exceeded_tenure_extend() {
             vec![(sender_addr, (send_amt + send_fee) * 1000)],
             |c| {
                 c.validate_with_replay_tx = true;
-                c.tenure_idle_timeout = Duration::from_secs(10);
+                c.tenure_idle_timeout = Duration::from_secs(120);
             },
             |node_config| {
                 node_config.miner.block_commit_delay = Duration::from_secs(1);
@@ -5024,7 +5024,10 @@ fn tx_replay_budget_exceeded_tenure_extend() {
         .submit_contract_call(&sender_sk, "big-contract", "big-tx", &vec![])
         .unwrap();
 
+    // new tenure, so the tx can fit
     info!("---- Waiting for second big tx to be mined ----");
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
 
     signer_test
         .wait_for_nonce_increase(&sender_addr, txid2_nonce)

--- a/testnet/stacks-node/src/tests/signer/v0.rs
+++ b/testnet/stacks-node/src/tests/signer/v0.rs
@@ -54,10 +54,10 @@ use stacks::codec::StacksMessageCodec;
 use stacks::config::{Config as NeonConfig, EventKeyType, EventObserverConfig};
 use stacks::core::mempool::MemPoolWalkStrategy;
 use stacks::core::test_util::{
-    insert_tx_in_mempool, make_contract_call, make_contract_publish,
+    insert_tx_in_mempool, make_big_read_count_contract, make_contract_call, make_contract_publish,
     make_stacks_transfer_serialized, to_addr,
 };
-use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET};
+use stacks::core::{StacksEpochId, CHAIN_ID_TESTNET, HELIUM_BLOCK_LIMIT_20};
 use stacks::libstackerdb::StackerDBChunkData;
 use stacks::net::api::getsigner::GetSignerResponse;
 use stacks::net::api::postblock_proposal::{
@@ -3382,7 +3382,7 @@ fn tx_replay_forking_test() {
     signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
 
     let (contract_deploy_txid, deploy_nonce) = signer_test
-        .submit_contract_deploy(&sender_sk, contract_code, contract_name)
+        .submit_contract_deploy(&sender_sk, 1000, contract_code, contract_name)
         .expect("Failed to submit contract deploy");
     signer_test
         .wait_for_nonce_increase(&sender_addr, deploy_nonce)
@@ -4934,6 +4934,178 @@ fn snapshot_test() {
     signer_test
         .wait_for_nonce_increase(&sender_addr, transfer_nonce)
         .expect("Timed out waiting for nonce to increase");
+
+    signer_test.shutdown();
+}
+
+#[test]
+#[ignore]
+/// Trigger a Bitcoin fork that creates a replay set that
+/// contains more transactions than can fit into a tenure's budget.
+fn tx_replay_budget_exceeded_tenure_extend() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let num_signers = 5;
+    let sender_sk =
+        Secp256k1PrivateKey::from_seed(format!("sender_{}", function_name!()).as_bytes());
+    let sender_addr = tests::to_addr(&sender_sk);
+    let send_amt = 1000;
+    let send_fee = 1000000;
+    let signer_test: SignerTest<SpawnedSigner> =
+        SignerTest::new_with_config_modifications_and_snapshot(
+            num_signers,
+            vec![(sender_addr, (send_amt + send_fee) * 1000)],
+            |c| {
+                c.validate_with_replay_tx = true;
+                c.tenure_idle_timeout = Duration::from_secs(10);
+            },
+            |node_config| {
+                node_config.miner.block_commit_delay = Duration::from_secs(1);
+                node_config.miner.replay_transactions = true;
+                node_config.miner.activated_vrf_key_path =
+                    Some(format!("{}/vrf_key", node_config.node.working_dir));
+            },
+            None,
+            None,
+            Some(function_name!()),
+        );
+    let conf = &signer_test.running_nodes.conf;
+    let _http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let _stacks_miner_pk = StacksPublicKey::from_private(&conf.miner.mining_key.unwrap());
+
+    let btc_controller = &signer_test.running_nodes.btc_regtest_controller;
+
+    if signer_test.bootstrap_snapshot() {
+        signer_test.shutdown_and_snapshot();
+        return;
+    }
+
+    info!("------------------------- Reached Epoch 3.0 -------------------------");
+    let pre_fork_tenures = 10;
+
+    for i in 0..pre_fork_tenures {
+        info!("Mining pre-fork tenure {} of {pre_fork_tenures}", i + 1);
+        signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    }
+
+    signer_test.check_signer_states_normal();
+
+    info!("---- Deploying big contract ----");
+
+    // First, just deploy the contract in its own tenure
+    let contract_code = make_big_read_count_contract(HELIUM_BLOCK_LIMIT_20, 50);
+
+    let (_deploy_txid, deploy_nonce) = signer_test
+        .submit_contract_deploy(&sender_sk, 1000000, contract_code.as_str(), "big-contract")
+        .unwrap();
+
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, deploy_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+    signer_test.mine_nakamoto_block(Duration::from_secs(30), true);
+
+    let tip = get_chain_info(conf);
+
+    let (txid1, txid1_nonce) = signer_test
+        .submit_contract_call(&sender_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+
+    info!("---- Waiting for first big tx to be mined ----");
+
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, txid1_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    let (txid2, txid2_nonce) = signer_test
+        .submit_contract_call(&sender_sk, "big-contract", "big-tx", &vec![])
+        .unwrap();
+
+    info!("---- Waiting for second big tx to be mined ----");
+
+    signer_test
+        .wait_for_nonce_increase(&sender_addr, txid2_nonce)
+        .expect("Timed out waiting for nonce to increase");
+
+    wait_for(30, || {
+        let new_tip = get_chain_info(&conf);
+        Ok(new_tip.stacks_tip_height > tip.stacks_tip_height)
+    })
+    .expect("Timed out waiting for transfer tx to be mined");
+
+    info!("------------------------- Triggering Bitcoin Fork -------------------------");
+
+    let burn_header_hash_to_fork = btc_controller.get_block_hash(tip.burn_block_height - 1);
+    btc_controller.invalidate_block(&burn_header_hash_to_fork);
+    btc_controller.build_next_block(3);
+
+    // note, we should still have normal signer states!
+    // signer_test.check_signer_states_normal();
+
+    info!("Wait for block off of shallow fork");
+
+    TEST_MINE_STALL.set(true);
+
+    let submitted_commits = signer_test
+        .running_nodes
+        .counters
+        .naka_submitted_commits
+        .clone();
+
+    // we need to mine some blocks to get back to being considered a frequent miner
+    for i in 0..3 {
+        let current_burn_height = get_chain_info(&conf).burn_block_height;
+        info!(
+            "Mining block #{i} to be considered a frequent miner";
+            "current_burn_height" => current_burn_height,
+        );
+        let commits_count = submitted_commits.load(Ordering::SeqCst);
+        next_block_and(btc_controller, 60, || {
+            Ok(submitted_commits.load(Ordering::SeqCst) > commits_count)
+        })
+        .unwrap();
+    }
+
+    let mut last_log = Instant::now();
+    last_log -= Duration::from_secs(5);
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let Some(tx_replay_set) = state.get_tx_replay_set() else {
+                if last_log.elapsed() > Duration::from_secs(5) {
+                    info!("---- tx_replay_set: none -----");
+                    last_log = Instant::now();
+                }
+                return Ok(false);
+            };
+            let len_ok = tx_replay_set.len() == 2;
+            let txid1_ok = tx_replay_set[0].txid().to_hex() == txid1;
+            let txid2_ok = tx_replay_set[1].txid().to_hex() == txid2;
+            if last_log.elapsed() > Duration::from_secs(5) {
+                info!("---- tx_replay_set: -----";
+                    "len" => tx_replay_set.len(),
+                    "txid1" => tx_replay_set[0].txid().to_hex(),
+                    "txid2" => tx_replay_set[1].txid().to_hex(),
+                );
+                last_log = Instant::now();
+            }
+            Ok(len_ok && txid1_ok && txid2_ok)
+        })
+        .expect("Timed out waiting for tx replay set");
+
+    TEST_MINE_STALL.set(false);
+
+    info!("---- Waiting for replay set to be cleared ----");
+
+    // Now, wait for the tx replay set to be cleared
+    signer_test
+        .wait_for_signer_state_check(30, |state| {
+            let tx_replay_set = state.get_tx_replay_set();
+            Ok(tx_replay_set.is_none())
+        })
+        .expect("Timed out waiting for tx replay set to be cleared");
 
     signer_test.shutdown();
 }


### PR DESCRIPTION
- Closes https://github.com/stacks-network/stacks-core/issues/5972

I'm opening this as a draft, because it builds on top of [test snapshots](https://github.com/stacks-network/stacks-core/pull/6163) and [6180 for using signer state when evaluating proposals](https://github.com/stacks-network/stacks-core/pull/6180).

This implements the functionality for miners issuing TenureExtends during transaction replay, which is important to help us clear out a replay set that is larger than the block budget.

The way this PR implements this functionality is simple: if we're in replay mode, always issue a TenureExtend.